### PR TITLE
feat: Display images and name with a clickable link after search

### DIFF
--- a/formpage.js
+++ b/formpage.js
@@ -11,11 +11,18 @@ $(document).ready(function() {
         good_with_children: $('input[name="kids"]:checked').val(),
         good_with_dogs: $('input[name="dogs"]:checked').val(),
         location: $('input[name="zip"]').val()
-
       },
       function(pets) {
         pets.forEach(function(pet) {
-          $("#pets-list").append(`<li>${pet.name}</li>`);
+          $("#pets-list").append(`
+            <li>
+                <a href="${pet.url}">
+                    <img src="${pet.photos[0].small}"><img>
+                    <p>${pet.name}</p>
+                </a>
+             </li>
+        `);
+
           console.log(pet);
         });
       }


### PR DESCRIPTION
### Description
Now when a user searches for pets to adopt based on their profile, we will display an image with their name that links to the adoption page on the Petfinder site.

![Screen Shot 2019-12-14 at 12 13 02 PM](https://user-images.githubusercontent.com/54917317/70852067-1623cb80-1e6b-11ea-9dc2-825de04ecc0a.png)

### Future Work
- [ ] Hide form after user clicks search
- [ ] Style image/name links
